### PR TITLE
 Adapt to new Crystallize image object

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,16 @@ import Image from '@crystallize/react-image';
 />
 ```
 
+## Support for PIM Image objects (v2.5.0+)
+
+```
+<Image
+    crystallizeImgObj={i}
+    withZoom // Optional: Click image to zoom in
+    sizes="" // Optional: Replace default media queries for srcset
+/>
+```
+
 ## Options
 
 ### src[string]: required

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@crystallize/react-image",
   "description": "A React package to output an img tag with different source variations from Crystallize",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@crystallize/react-image",
   "description": "A React package to output an img tag with different source variations from Crystallize",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@babel/register": "^7.0.0",
     "parcel-bundler": "^1.9.2",
     "react": "^16.2.0",
+    "react-medium-image-zoom": "^3.1.0",
     "react-dom": "^16.2.0",
     "webpack": "^4.12.0",
     "webpack-cli": "^3.0.8",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@crystallize/react-image",
   "description": "A React package to output an img tag with different source variations from Crystallize",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
+import ImageZoom from 'react-medium-image-zoom';
 
 // The default image variations created by Crystallize
 const imageVariations = "320 414 768 1280 1536 1920 2560 3200".split(" ");
@@ -48,9 +49,45 @@ class CrystallizeImage extends React.Component {
     return srcVariations[0];
   }
 
+  getSrcSet(srcVariations, type) {
+    return srcVariations.map(variant => {
+      const format = variant.url.split('.').slice(-1)[0];
+      if (format === type) return `${variant.url} ${variant.width}w`;
+    }).join(",");
+  }
+
+  onImageLoad = e => alert(e.target.currentSrc);
+
+  handleCrystallizeImage(crystallizeImgObj, rest) {
+
+    if (crystallizeImgObj && crystallizeImgObj.variants) {
+      const webpSrcSet = this.getSrcSet(crystallizeImgObj.variants, 'webp');
+      const jpgSrcSet = this.getSrcSet(crystallizeImgObj.variants, 'jpg');
+      return <>
+        <picture>
+          <source srcSet={webpSrcSet} src={crystallizeImgObj.url} type="image/webp" sizes={rest.sizes ? rest.sizes : '(max-width: 700px) 500px, 800px'} />
+          <source srcSet={jpgSrcSet} src={crystallizeImgObj.url} type="image/jpg" sizes={rest.sizes ? rest.sizes : '(max-width: 700px) 500px, 800px'} />
+          {rest.withZoom && rest.withZoom === true ? <ImageZoom
+            image={{
+              src: crystallizeImgObj.url,
+              alt: crystallizeImgObj.altText,
+              onLoad: this.onImageLoad
+            }}
+          /> : <img onLoad={onImageLoad} src={crystallizeImgObj.url} alt={crystallizeImgObj.altText} />}
+        </picture>
+      </>
+    } else {
+      return <img src={crystallizeImgObj.url} {...rest} />
+    }
+  }
+
   render() {
-    const { media, src, srcVariations, product_image, ...rest } = this.props;
+    const { media, src, srcVariations, product_image, imageZoom, crystallizeImgObj, ...rest } = this.props;
     let srcToUse = src;
+
+    if (crystallizeImgObj, rest) {
+      return this.handleCrystallizeImage(crystallizeImgObj, rest);
+    }
 
     if (media && media.url) {
       srcToUse = media.url;

--- a/src/index.js
+++ b/src/index.js
@@ -56,8 +56,6 @@ class CrystallizeImage extends React.Component {
     }).join(",");
   }
 
-  onImageLoad = e => alert(e.target.currentSrc);
-
   handleCrystallizeImage(crystallizeImgObj, rest) {
 
     if (crystallizeImgObj && crystallizeImgObj.variants) {
@@ -70,8 +68,7 @@ class CrystallizeImage extends React.Component {
           {rest.withZoom && rest.withZoom === true ? <ImageZoom
             image={{
               src: crystallizeImgObj.url,
-              alt: crystallizeImgObj.altText,
-              onLoad: this.onImageLoad
+              alt: crystallizeImgObj.altText
             }}
           /> : <img onLoad={onImageLoad} src={crystallizeImgObj.url} alt={crystallizeImgObj.altText} />}
         </picture>

--- a/src/index.js
+++ b/src/index.js
@@ -70,7 +70,7 @@ class CrystallizeImage extends React.Component {
               src: crystallizeImgObj.url,
               alt: crystallizeImgObj.altText
             }}
-          /> : <img onLoad={onImageLoad} src={crystallizeImgObj.url} alt={crystallizeImgObj.altText} />}
+          /> : <img src={crystallizeImgObj.url} alt={crystallizeImgObj.altText} />}
         </picture>
       </>
     } else {


### PR DESCRIPTION
Works with Crystallize PIM new Image object (non-breaking release v2.5.0):

- Use srcset for responsive images with new Crystallize Image object
- Use webp on webp compatible browsers for optimized network usage
- Use image srcset for browser source resolution based on https://crystallize.com/blog/react-image-sizes-attribute-for-fast-ecommerce
- Override `size` property media query for img srcSet
- Fallback solution for browsers incompatible with srcset or webp
- Optional: react-image-zoom for full screen image on image click