### PR TITLE
Mark `height` of `CrystallizeImageVariant` as optional

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,7 +3,7 @@ import React, { FC, HTMLAttributes, FunctionComponent } from 'react';
 export interface CrystallizeImageVariant {
   url: string;
   width: number;
-  height: number;
+  height?: number;
   size?: number;
 }
 


### PR DESCRIPTION
According to the GraphQL schema, `height` is optional:

```gql
type ImageVariant {
  url: String!
  key: String!
  width: Int!
  height: Int
  size: Int
}
```

This means that when using something like [GraphQL Code Generator](https://www.graphql-code-generator.com/), the generated types will become:

```ts
type ImageVariant = {
  __typename?: 'ImageVariant';
  url: Scalars['String'];
  key: Scalars['String'];
  width: Scalars['Int'];
  height?: Maybe<Scalars['Int']>;
  size?: Maybe<Scalars['Int']>;
};
```

These types are incompatible as `height` is marked as optional in the generated type.

Looking at the code, it looks like only `width` is required to calculate the `biggestImage` variant. The resulting `height` which is used in `commonProps` can be `undefined` as we may not have a `biggestImage` (`height: biggestImage?.height`).